### PR TITLE
Refactor Forum Events Plugin

### DIFF
--- a/events/form.php
+++ b/events/form.php
@@ -29,7 +29,7 @@ require_login();
 require_capability('local/forum_events:manage', context_system::instance());
 $PAGE->set_context(context_system::instance());
 $PAGE->set_pagelayout('admin');
-$PAGE->set_title("forum Event");
+$PAGE->set_title("Forum Event");
 $PAGE->set_url($CFG->wwwroot.'/local/forum_events/events/form.php');
 $PAGE->requires->js_call_amd('local_forum_events/forum_events', 'event_form');
 $PAGE->requires->css('/local/forum_events/chosen.css');
@@ -85,6 +85,6 @@ echo html_writer::tag('p', "See the $eventlist for details about all available e
 
 $mform->display();
 
-echo html_writer::tag('p', 'The Subject and Body field also has access to $moodle_event, $course, $user and $user_profile (custom profile fields).', array('class' => 'description'));
+echo html_writer::tag('p', 'The Subject and Body field also has access to certain variables. They can access {course_coach}, {course_coach_email}, {course_coach_first_name}, {course_start_date}, {course_fullname}, {course_section_name}, {final_results} and {final_access}. More can be added at request.', array('class' => 'description'));
 
 echo $OUTPUT->footer();

--- a/settings.php
+++ b/settings.php
@@ -55,9 +55,9 @@ $setting = new admin_setting_configtextarea($name, $title, $description, $defaul
 $temp->add($setting);
 
 $name = 'local_forum_events/forumrole';
-$title = 'forum from role';
-$description = 'Select the role who will create the forum';
-$default = 5;
+$title = 'Forum Events Course Coach';
+$description = 'Select the role of the course coach. This role will be the user who creates the forum post and that is used for the {course_coach}, {course_coach_email} etc. placeholders.';
+$default = 100;
 $context = context_course::instance(1); // site wide course context
 $roles = get_assignable_roles($context);
 $setting = new admin_setting_configselect($name, $title, $description, $default, $roles);


### PR DESCRIPTION
Made it so that the course coach pulls from this plugin rather than relying on the data pulled through the other field in the event record. This allows us to centralise this funcitonality and takes the dependancy out of the events. It also allows us to make use of core moodle events not just our custom ones as it just uses the courseid to determine the course coach.
